### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-promille-def.R
+++ b/feedback/topdown-promille-def.R
@@ -1,0 +1,105 @@
+## hier aus didaktischen Gründen teilweise englische und deutsche Kommentare gemischt.
+## sie sollten englische Kommentare schreiben (in diesem Kurs & wann immer sie
+## vorhaben anderen Ihren Code zugänglich zu machen.)
+
+# computes approximate BAC (in per mille) at the end of the party (drinking_time[2])
+#
+# method:
+# https://web.archive.org/web/20150123143123/http://promille-rechner.org/erlaeuterung-der-promille-berechnung/
+# massn: 1l@6%; hoibe: 0.5l@6%; wein: 0.2l@11%; schnaps: 0.04l@40%
+#
+# inputs:
+#   age in years
+#   height in cm
+#   weight in kg
+#   drinking_time: sorted POSIXct vector giving start and end of the party
+#   drinks: list or vector with names "massn", "hoibe", "wein", "schnaps"
+#     counting the number consumed of each type of drink
+#  output:
+#    approximate BAC in per mille
+tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight,
+                              drinking_time, drinks) {
+  # inputs homogen machen:
+  drinks <- unlist(drinks)
+  sex <- tolower(sex)
+  # inputs checken:
+  checkmate::assert_number(age,
+                           lower = 10, upper = 110)
+  sex <- match.arg(sex)
+  checkmate::assert_number(height,
+                           lower = 100, upper = 230)
+  checkmate::assert_number(weight,
+                           lower = 40, upper = 300)
+  checkmate::assert_subset(names(drinks),
+                           choices = c("massn", "hoibe", "wein", "schnaps"),
+                           empty.ok = FALSE)
+  checkmate::assert_numeric(drinks,
+                            lower = 0, any.missing = FALSE, min.len = 1)
+  checkmate::assert_posixct(drinking_time,
+                            any.missing = FALSE, sorted = TRUE, len = 2)
+
+  # isTRUE weil drinks["schnaps"] NA ist wenn kein "schnaps"-Eintrag da ist.
+  illegal <- (age < 16 & sum(drinks) > 0) |
+             (age < 18 & isTRUE(drinks["schnaps"] > 0))
+  if (illegal) {
+    warning("\u2639 ...illegal!  \u2639")
+  }
+
+  alcohol_drunk <- get_alcohol(drinks)
+  bodywater <- get_bodywater(sex, age, height, weight)
+  max_permille <- get_permille(alcohol_drunk, bodywater)
+  sober_up(max_permille, drinking_time)
+}
+
+# compute consumed alcohol in g
+# massn, hoibe: 6%; wein: .2l@11%; schnaps: 4cl@40%
+get_alcohol <- function(drinks) {
+  # in ml
+  volume <- c(
+    "massn" = 1000,
+    "hoibe" = 500,
+    "wein" = 200,
+    "schnaps" = 40
+  )
+  # in volume-%
+  alcohol_concentration <- c(
+    "massn" = 0.06,
+    "hoibe" = 0.06,
+    "wein" = 0.11,
+    "schnaps" = 0.4
+  )
+  alcohol_density <- 0.8
+
+  # die indizierung mit names(drinks) erzeugt vektoren von volumen
+  # und alkoholgehalt die zu den einträgen in drinks passen
+  # (richtige reihenfolge & laenge):
+  sum(drinks * volume[names(drinks)] *
+        alcohol_concentration[names(drinks)] * alcohol_density)
+}
+
+# compute amount of water in a human body
+# coefficients from web-site promillerechner.org linked above
+get_bodywater <- function(sex = c("male", "female"), age, height, weight) {
+  coefficients <- switch(sex,
+                         "male"   = c(2.447, -0.09516, 0.1074, 0.3362),
+                         "female" = c(0.203, -0.07, 0.1069, 0.2466))
+ t(coefficients) %*% c(1, age, height, weight)
+}
+
+# compute max BAC (assumed: at drinking_time[1]...)
+get_permille <- function(alcohol_drunk, bodywater) {
+  alcohol_density <- 0.8
+  blood_density <- 1.055
+  permille <- alcohol_density * alcohol_drunk / (blood_density * bodywater)
+  permille
+}
+
+# compute BAC at drinking_time[2]
+sober_up <- function(permille, drinking_time) {
+  partylength <- difftime(drinking_time[2], drinking_time[1], units = "hours")
+  sober_per_hour <- 0.15
+  # abbau beginnt erst nach einer stunde:
+  depletion_duration <- max(0, partylength - 1)
+  # abbau kann nicht zu negativen promille führen:
+  max(0, permille - depletion_duration * sober_per_hour)
+}

--- a/feedback/topdown-promille-sol.Rmd
+++ b/feedback/topdown-promille-sol.Rmd
@@ -1,0 +1,12 @@
+```{r, child = "topdown-promille-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+Zum Beispiel so:
+```{r, def_promillerechner, code = readLines("topdown-promille-def.R"), echo=TRUE}
+```
+
+Die Fehlermeldungen könnte man hier sicher noch etwas informativer und allgemeinverständlicher machen indem man statt `checkmate::assert_XY` jeweils `if(<argument ungeeignet>) stop("<allgemeinverständliche Fehlermeldung>")` benutzt.  


### PR DESCRIPTION
@corneliagru 

Top-Down Design sehr gut gemacht, super. 
Input checks und Programmlogik großteils ebenso - sehr toll, weiter so!

----------------------------------------------

Details:

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L39 fehlt: `min.len = 1`

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L43 styleguide! `assert_names` bitte

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L47 gute idee zum inputs homogen machen! 

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L92-L93
s.a. `assert_number, assert_string, assert_flag` um direkt skalare inputs ohne `len=1` zu checken.

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L119-L129 
das hätte dann finde ich auch nochmal (oder sogar zweimal) eingekapselt gehört

- https://github.com/fort-w2021/promille-ex-corneliagru/blob/4e79d63db9f5f70a43625133efda6b4721e9051f/topdown-promille-sol.Rmd#L137... ok, also *nach* 3 maß und 4 schnaps ist der tag dann meiner erfahrung nach nicht mehr so wunderbar.... 

---------------------------------------------------------------------------------------------
offene fragen:

> Frage1: lieber alle assert_bla in den jeweiligen Unterfunktionen in denen die
 variable genutzt wird oder alle am anfang des aufrufs von tell_me_how_drunk?
 Vorteil bei Unterfunktionen: alle abfragen dort wo sie benötigt werden,
 nachteil: es wird im schlimmsten fall bereits viel vorberechnet bis man auf
 einen fehler stößt

ich bin eher für "alle am anfang der top level funktion": klarere struktur, selbst-dokumentierender code bzgl anforderungen an inputs.

> Frage2: wie kann man den error wenn die getränke nicht den erlaubten drinks
 entsprechen besser machen? ich hätte gerne die fehlermeldung "only bla allowed.
 not 'your_stupid_fancy_drink'" (check ist in format_drinks())
sowas à la
```r
too_fancy <- !(names(drinks) %in% allowed_drinks)
if(any(too_fancy)) stop(names(drinks)[too_fancy], "are too fancy and not allowed.")
```
 sollte gehen. das aber nebenkriegsschauplatz, für uns sind die checkmate fehlermeldungen erst mal gut so, bitte nicht anfangen jetzt immer eigene assertions & fehlermeldungen zu programmieren.
`assert_subset` ist auch bischn informativer als `assert_names`:
```r
> assert_subset(c(1, 2), choices = c(2, 3))
Error: Assertion on 'c(1, 2)' failed: Must be a subset of {'2','3'}, but is {'1','2'}.
> assert_names(names(c(a = 1, b = 2)), subset.of = c("b", "c"))
Error: Assertion on 'names(c(a = 1, b = 2))' failed: Must be a subset of set {b,c}.
 ```
> Frage 3: was muss ich machen damit ich bei den tests oben rechts in Rstudio
 einfach "run tests" laufen lassen kann? Error: konnte Funktion
 "tell_me_how_drunk" nicht finden. Vermutung: es reicht nicht dass die funktion
 im global environment ist?

Nicht sicher, funktioniert bei mir auch nicht. Kann man auch ganz normal laufen lassen (per source oder besser mit `testthat::test_file("topdown-promille-tests.R")`)
Dieser button in Rstudio ist glaub ich eher für echte R-paket-entwicklung (nach Weihnachten dann...)
Allerdings: grundsätzlich würde ich Code in echte R-skripte schreiben nicht so wie sie hier in Rmd files.



> * Frage 4: wann braucht am ende einer funktion "return(bla)" anstatt nur "bla"?
was ist zu bevorzugen?

braucht es am ende nie. das ergebnis des letzten ausgewerteten ausdrucks im funktionsrumpf wird zurückgegeben.  
also: am ende nie `return`, sollte für *early exits* reserviert sein-